### PR TITLE
FIX number of deleted graphicscomponent to remove memory leak

### DIFF
--- a/SSPSolution/GraphicsDLL/GraphicsHandler.cpp
+++ b/SSPSolution/GraphicsDLL/GraphicsHandler.cpp
@@ -392,7 +392,7 @@ void GraphicsHandler::Shutdown()
 	{
 		this->m_windowHandle = nullptr;
 	}
-	for (int i = 0; i < this->m_nrOfGraphicsComponents; i++)
+	for (int i = 0; i < this->m_maxGraphicsComponents; i++)
 	{
 		if (this->m_graphicsComponents[i] != nullptr)
 		{


### PR DESCRIPTION
If only memory leaks could be nutrients.