### PR TITLE
Debug messages fix

### DIFF
--- a/SSPSolution/ResourceLib/MeshHandler.cpp
+++ b/SSPSolution/ResourceLib/MeshHandler.cpp
@@ -75,7 +75,13 @@ Resources::Status Resources::MeshHandler::LoadMesh(const unsigned int & id, Reso
 
 	Status st = FileLoader::GetInstance()->LoadResource(id ,data, &dataSize);
 	if (st != ST_OK)
+	{
+#ifdef _DEBUG
+		std::cout << "Failed to load  Mesh | ID : " << id << std::endl;
+#endif // DEBUG
 		return st;
+
+	}
 	
 	//additional headers could be added here,
 	Resource::RawResourceData* resData  = (Resource::RawResourceData*)data;
@@ -90,15 +96,18 @@ Resources::Status Resources::MeshHandler::LoadMesh(const unsigned int & id, Reso
 	MeshHeader* meshData = (MeshHeader*)(data + sizeof(Resource::RawResourceData));
 	unsigned int*			   indices  = nullptr;
 	
-#ifdef _DEBUG
-	std::cout << "Loading new Mesh | ID : " << resData->m_id << std::endl;
-#endif // DEBUG
+
 
 	Mesh* newMesh = GetEmptyContainer();		//Get an empty container
 	st = newMesh->Create(resData); //Initialize it with data
 
-	if (st != ST_OK)
+	if (st != ST_OK) {
+
+#ifdef _DEBUG
+		std::cout << "Failed to create  Mesh | ID : " << id << std::endl;
+#endif // DEBUG
 		return st;
+	}
 	BoundingBoxHeader* obbdataPtr;
 	if (meshData->skeleton)
 	{
@@ -163,8 +172,13 @@ Resources::Status Resources::MeshHandler::LoadPlaceHolderMesh()
 	char* data = nullptr;
 	size_t dataSize = 0;
 	Status st = FileLoader::GetInstance()->LoadPlaceHolderMesh(path, data, &dataSize);
-	if (st != ST_OK)
+	if (st != ST_OK) {
+
+#ifdef _DEBUG
+		std::cout << "Failed to load placeHolder mesh" << std::endl;
+#endif // DEBUG
 		return st;
+	}
 
 	//additional headers could be added here,
 	Resource::RawResourceData* resData = (Resource::RawResourceData*)data;
@@ -176,9 +190,7 @@ Resources::Status Resources::MeshHandler::LoadPlaceHolderMesh()
 	MeshHeader* meshData = (MeshHeader*)(data + sizeof(Resource::RawResourceData));
 	unsigned int*			   indices = nullptr;
 
-#ifdef _DEBUG
-	std::cout << "Loading placeHolder mesh" << std::endl;
-#endif // DEBUG
+
 	st = m_placeHolder->Create((Resource::RawResourceData*)data); //Initialize it with data
 
 	if (st != ST_OK)

--- a/SSPSolution/ResourceLib/ResourceHandler.cpp
+++ b/SSPSolution/ResourceLib/ResourceHandler.cpp
@@ -109,7 +109,7 @@ Resources::Status Resources::ResourceHandler::LoadLevel(LevelData::ResourceHeade
 	FileLoader* fileLoader = Resources::FileLoader::GetInstance();
 	if (!fileLoader->OpenFile(Resources::FileLoader::Files::BPF_FILE))
 	{
-		std::cout << "Could not open resource file" << std::endl;
+		std::cout << "Could not open BPF file" << std::endl;
 		return ST_ERROR_OPENING_FILE;
 	}
 
@@ -133,7 +133,7 @@ Resources::Status Resources::ResourceHandler::LoadLevel(LevelData::ResourceHeade
 		case Resources::Status::ST_RES_MISSING:
 		{
 #ifdef _DEBUG
-			std::cout << "Model missing, loading" << std::endl;
+			//std::cout << "Model not loaded, loading" << std::endl;
 #endif // _DEBUG
 			//Load the model
 			Status modelSt = m_modelHandler->LoadModel(id, modelPtr); //if this fails, placeholder will take the place

--- a/SSPSolution/ResourceLib/ResourceHandler.h
+++ b/SSPSolution/ResourceLib/ResourceHandler.h
@@ -49,7 +49,7 @@ namespace Resources
 
 
 	private:
-		Resources::Status UnloadLevel(LevelResources* levelRes); //this will be private later (public for tests)
+		Resources::Status UnloadLevel(LevelResources* levelRes); 
 	};
 }
 

--- a/SSPSolution/ResourceLib/TextureHandler.cpp
+++ b/SSPSolution/ResourceLib/TextureHandler.cpp
@@ -182,9 +182,7 @@ bool Resources::TextureHandler::LoadPlaceHolderTextures()
 	if (placeHolder != nullptr)
 		return false;
 
-#ifdef _DEBUG
-	std::cout << "Loading Placeholder Texture" << std::endl;
-#endif // _DEBUG
+
 
 	
 	/*T E M P*/
@@ -259,16 +257,16 @@ bool Resources::TextureHandler::LoadPlaceHolderTextures()
 
 			if (FAILED(hr)) //If it still doesent work, there  is a problem
 			{
-#ifdef _DEBUG
-				std::cout << "Could not open texture file : " << path_str[i] << std::endl;
-#endif // _DEBUG
+			#ifdef _DEBUG
+							std::cout << "Could not open texture file : " << path_str[i] << std::endl;
+			#endif // _DEBUG
 				return false;
 			}
 		}
 		
-#ifdef _DEBUG
-			std::cout << "Opened file : " << path_str[i] << std::endl;
-#endif // _DEBUG
+//#ifdef _DEBUG
+//			std::cout << "Opened file : " << path_str[i] << std::endl;
+//#endif // _DEBUG
 		
 
 


### PR DESCRIPTION
The debug messages in the resource lib has been changed to only notify when any loading operation fails. Instead of printing when something succeeds