### PR TITLE
Quick throw

### DIFF
--- a/SSPSolution/SSPSolution/GameStateHandler.h
+++ b/SSPSolution/SSPSolution/GameStateHandler.h
@@ -5,7 +5,7 @@
 #include "LevelSelectState.h"
 #include <vector>
 
-//#define START_WITHOUT_MENU
+#define START_WITHOUT_MENU
 
 class GameStateHandler
 {

--- a/SSPSolution/SSPSolution/LevelState.cpp
+++ b/SSPSolution/SSPSolution/LevelState.cpp
@@ -697,9 +697,11 @@ int LevelState::Update(float dt, InputHandler * inputHandler)
 	#pragma endregion Update/Syncing Components
 
 	#pragma region
-		if (inputHandler->IsMouseKeyPressed(SDL_BUTTON_LEFT) && this->m_player1.GetGrabbed() == nullptr && !inputHandler->IsMouseKeyDown(SDL_BUTTON_RIGHT))
+		if (inputHandler->IsMouseKeyPressed(SDL_BUTTON_LEFT) 
+			&& this->m_player1.GetGrabbed() == nullptr
+			&& this->m_player1.TimeSinceThrow() >= GRAB_COOLDOWN)
 		{
-			Entity* closestBall = this->GetClosestBall(3);
+			Entity* closestBall = this->GetClosestBall(GRAB_RANGE);
 			
 			if (closestBall != nullptr)	//If a ball was found
 			{				

--- a/SSPSolution/SSPSolution/LevelState.h
+++ b/SSPSolution/SSPSolution/LevelState.h
@@ -23,6 +23,9 @@
 #define BALL1_ID 1
 #define BALL2_ID 1
 #define CHAIN_ID 1
+const int GRAB_COOLDOWN = 1;	//Cooldown in seconds until player can grab something after a throw
+const int GRAB_RANGE = 3; //The range of the grab in meters
+
 
 // For testing
 #define DEVELOPMENTFUNCTIONS

--- a/SSPSolution/SSPSolution/Player.cpp
+++ b/SSPSolution/SSPSolution/Player.cpp
@@ -10,6 +10,7 @@ Player::Player()
 	this->m_isAiming = false;
 	this->m_walkingSound = nullptr;
 	this->m_oldAnimState = 0;
+	this->m_timeSinceThrow = 0;
 }
 
 Player::~Player()
@@ -237,36 +238,46 @@ int Player::Update(float dT, InputHandler* inputHandler)
 
 
 	//if (inputHandler->IsKeyPressed(SDL_SCANCODE_P))
-		if(inputHandler->IsMouseKeyPressed(SDL_BUTTON_LEFT) && inputHandler->IsMouseKeyDown(SDL_BUTTON_RIGHT))
+	bool hasThrown = false;
+	if(inputHandler->IsMouseKeyPressed(SDL_BUTTON_LEFT) && this->m_grabbed != nullptr)
+	{
+		//assumes grabbed is ALWAYS the ball
+		if (this->m_grabbed != nullptr)
 		{
-			//assumes grabbed is ALWAYS the ball
-			if (this->m_grabbed != nullptr)
+			this->m_oldAnimState = this->m_aComp->previousState;
+			SetAnimationComponent(PLAYER_THROW, 0.4f, Blending::FROZEN_TRANSITION, false, true, 2.0f, 1.0f);
+			this->m_aComp->velocity = 1.0f;
+			this->m_aComp->previousState = PLAYER_THROW;
+			//Play sound
+			DirectX::XMFLOAT3 pos;
+			DirectX::XMStoreFloat3(&pos, this->GetPhysicsComponent()->PC_pos);
+			SoundHandler::instance().PlayRandomSound3D(Sounds3D::STUDLEY_THROW_1, Sounds3D::STUDLEY_THROW_3, pos, false, false);
+				
+			float strength = 25.0f; //stregth higher than 50 can cause problems pullinh through walls and such
+
+			//if the player is holding its own ball
+			if (this->m_ball->GetEntityID() == this->m_grabbed->GetEntityID())
 			{
-				this->m_oldAnimState = this->m_aComp->previousState;
-				SetAnimationComponent(PLAYER_THROW, 0.4f, Blending::FROZEN_TRANSITION, false, true, 2.0f, 1.0f);
-				this->m_aComp->velocity = 1.0f;
-				this->m_aComp->previousState = PLAYER_THROW;
-				//Play sound
-				DirectX::XMFLOAT3 pos;
-				DirectX::XMStoreFloat3(&pos, this->GetPhysicsComponent()->PC_pos);
-				SoundHandler::instance().PlayRandomSound3D(Sounds3D::STUDLEY_THROW_1, Sounds3D::STUDLEY_THROW_3, pos, false, false);
-				
-				float strength = 25.0f; //stregth higher than 50 can cause problems pullinh through walls and such
-
-				//if the player is holding its own ball
-				if (this->m_ball->GetEntityID() == this->m_grabbed->GetEntityID())
-				{
-					strength = 2; //weak as föök if the player tries to throw himself
-				}
-
-				
-				m_grabbed->GetPhysicsComponent()->PC_active = true;
-				this->m_grabbed->GetPhysicsComponent()->PC_velocity = DirectX::XMVectorScale(this->m_lookDir, strength);
-				this->m_grabbed->GetPhysicsComponent()->PC_gravityInfluence = 1;
-
-				this->SetGrabbed(nullptr);	//Release the entity
+				strength = 2; //weak as föök if the player tries to throw himself
 			}
+
+				
+			m_grabbed->GetPhysicsComponent()->PC_active = true;
+			this->m_grabbed->GetPhysicsComponent()->PC_velocity = DirectX::XMVectorScale(this->m_lookDir, strength);
+			this->m_grabbed->GetPhysicsComponent()->PC_gravityInfluence = 1;
+
+			this->SetGrabbed(nullptr);	//Release the entity
+
+			hasThrown = true;
+			this->m_timeSinceThrow = 0;
 		}
+	}
+
+	//Check if we have not thrown something
+	if (hasThrown == false)
+	{
+		this->m_timeSinceThrow += dT;	//Add time to timmer
+	}
 
 	//Check if player is grounded
 
@@ -560,4 +571,9 @@ bool Player::isAnimationChanged()
 	}
 
 	return result;
+}
+
+float Player::TimeSinceThrow()
+{
+	return this->m_timeSinceThrow;
 }

--- a/SSPSolution/SSPSolution/Player.h
+++ b/SSPSolution/SSPSolution/Player.h
@@ -23,6 +23,7 @@ private:
 
 	irrklang::ISound* m_walkingSound;
 	int	m_oldAnimState;
+	float m_timeSinceThrow;
 
 	UIComponent* m_controlsOverlay;
 
@@ -57,6 +58,7 @@ public:
 	Entity* GetGrabbed();
 	Entity* GetBall();
 	bool isAnimationChanged();	//Compares the current Animation State against the previous frame's Animation State 
+	float TimeSinceThrow();
 
 private:
 


### PR DESCRIPTION
Fixed so we can throw outside of aiming.
This is solved by adding an internal timer in player for which counts the time since last thrown and is then used to check if we can grab something.